### PR TITLE
Restrict Location Page Events to Festival Dates

### DIFF
--- a/app/controllers/festivity_events_controller.rb
+++ b/app/controllers/festivity_events_controller.rb
@@ -56,18 +56,8 @@ class FestivityEventsController < ApplicationController
     if params[:dates]
       params[:dates].split(",")
     else
-      collect_festival_dates
+      FestivityEventList.collect_festival_dates(current_site)
     end
-
-  end
-
-  def collect_festival_dates
-    festival_dates = current_site.festival_datetimes
-    if current_site.date_during_festival?(Time.now)
-      festival_dates = festival_dates.select{ |date| date.datetime == Time.now }
-    end
-
-    festival_dates.map{ |date| date.to_s }
 
   end
 

--- a/app/controllers/festivity_locations_controller.rb
+++ b/app/controllers/festivity_locations_controller.rb
@@ -7,7 +7,7 @@ class FestivityLocationsController < ApplicationController
     @location = FestivityLocationPage.find_by_slug_for_site(params[:id]).first
     if @location
       @location_events = @title = Rails.cache.fetch("location-#{@location.slug}", expires_in: 2.hours) do
-        FestivityEventList.find_by_location(@location.id)
+        FestivityEventList.find_by_location(@location.id, current_site)
       end
       @title = "#{current_site.festivity_festival_name}: #{@location.title}"
     else


### PR DESCRIPTION
Location pages will now only show events that fall within the current festival's date range.
