### PR TITLE
BugzID: 3015 - Events failing on related events

### DIFF
--- a/app/models/festivity_event_list.rb
+++ b/app/models/festivity_event_list.rb
@@ -105,7 +105,10 @@ class FestivityEventList
   # - Any category ids passed are added to the where clause as well.
   def self.parse_criteria(criteria)
     if criteria[:dates]
-      event_ids = event_ids_for_datetimes(criteria[:dates], criteria[:filter_type])
+      # related events fails if filter_type is nil - this is a fallback for nil filter_type
+      site_filter = Site.find_by_id(Page.current_site.id).festivity_filter_type
+      filter = criteria[:filter_type] ||= site_filter
+      event_ids = event_ids_for_datetimes(criteria[:dates], filter)
       raise ActiveRecord::RecordNotFound unless event_ids.any?
     end
 

--- a/app/views/festivity_events/show.html.haml
+++ b/app/views/festivity_events/show.html.haml
@@ -98,5 +98,5 @@
 - if @related_events.any?
   %section.related-events
     %h3 Related Events
-    -#- @related_events[0..2].each do |e|
-    -#  = render partial: 'event', locals: {event: e}
+    - @related_events[0..2].each do |e|
+      = render partial: 'event', locals: {event: e}


### PR DESCRIPTION
Related events were failing if the filter_type was nil in the events controller. Put in a fallback if the filter_type comes in nil to set the filter_type to what the database has. 
![6991202-hear-no-evil-see-no-evil-speak-no-evil-cartoon-monkeys](https://cloud.githubusercontent.com/assets/10598969/14364882/dfc4298e-fcd8-11e5-82be-b207ffffe006.jpg)
