### PR TITLE
See bugzid: 3357 & 3373 - Cache-control on controllers and CMS assets

### DIFF
--- a/app/controllers/festivity_events_controller.rb
+++ b/app/controllers/festivity_events_controller.rb
@@ -1,9 +1,9 @@
 class FestivityEventsController < ApplicationController
   include Concerns::FestivityCustomPage
   include Concerns::FestivitySearchCaching
+  before_action { expires_in 1.hour, :public => true }
 
   def index
-
     order_by = params[:sort] ? params[:sort] : "start_date"
     @title = "#{current_site.festivity_festival_name}: Events"
     @filter_type = current_site.festivity_filter_type

--- a/app/controllers/festivity_location_areas_controller.rb
+++ b/app/controllers/festivity_location_areas_controller.rb
@@ -1,5 +1,6 @@
 class FestivityLocationAreasController < ApplicationController
   include Concerns::FestivityCustomPage
+  before_action { expires_in 1.hour, :public => true }
 
   def show
     @area = FestivityLocationAreaPage.find_by_slug_for_site(params[:id]).first

--- a/app/controllers/festivity_locations_controller.rb
+++ b/app/controllers/festivity_locations_controller.rb
@@ -1,5 +1,6 @@
 class FestivityLocationsController < ApplicationController
   include Concerns::FestivityCustomPage
+  before_action { expires_in 1.hour, :public => true }
 
   def show
     @location = FestivityLocationPage.find_by_slug_for_site(params[:id]).first

--- a/app/controllers/festivity_markets_controller.rb
+++ b/app/controllers/festivity_markets_controller.rb
@@ -1,6 +1,7 @@
 class FestivityMarketsController < ApplicationController
   include Concerns::FestivityCustomPage
   include Concerns::FestivitySearchCaching
+  before_action { expires_in 1.hour, :public => true }
 
   def index
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,6 @@
 class SearchController < ApplicationController
   include Concerns::FestivityCustomPage
+  before_action { expires_in 1.hour, :public => true }
 
   def show
     query = params[:q].to_s

--- a/trusty-festivity-extension.gemspec
+++ b/trusty-festivity-extension.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "trusty-cms"                   , '>= 2.0.20'
-  s.add_dependency "trusty-clipped-extension"     , "~> 2.0.9"
+  s.add_dependency "trusty-clipped-extension"     , "~> 2.0.12"
   s.add_dependency "trusty-snippets-extension"    , "~> 2.0.7"
   s.add_dependency "trusty-reorder-extension"     , "~> 2.0.6"
   s.add_dependency "trusty-layouts-extension"     , "~> 2.0.4"


### PR DESCRIPTION
Delivers: 

https://pct.fogbugz.com/f/cases/3357/Festivity-Header-Cache-Control-max-age-0-private-must-revalidate-is-set-on-all-app-pages

https://pct.fogbugz.com/f/cases/3373/Festivity-Set-Cache-Control-on-assets
