### PR TITLE
See bugzid: 2779 - require no_login for Error pages

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,5 +1,5 @@
 class ErrorsController < ApplicationController
-  trusty_layout 'base'
+  include Concerns::FestivityCustomPage
 
   def internal_server_error
     render(:status => 500)


### PR DESCRIPTION
Delivers the rest of: https://pct.fogbugz.com/f/cases/resolve/2779/Need-solution-for-500-application-errors
