### PR TITLE
Crawl homepage

### DIFF
--- a/app/assets/stylesheets/globals/_general.scss
+++ b/app/assets/stylesheets/globals/_general.scss
@@ -232,3 +232,23 @@ img {
 .not-visually-hidden {
   @include not-visually-hidden;
 }
+
+//Bulleted List styles
+//////////////////////////////////////
+
+ul .bulleted-list, ol .ordered-list {
+  margin: 0 0 1.5em 2em;
+
+  li {
+    margin-bottom: 0.5em;
+  }
+}
+
+ul.bulleted-list {
+  list-style: disc;
+  margin-top: 0.5em;
+}
+
+ol.ordered-list {
+  list-style: decimal;
+}

--- a/app/assets/stylesheets/skins/crawl/contexts/_crawl.scss
+++ b/app/assets/stylesheets/skins/crawl/contexts/_crawl.scss
@@ -37,9 +37,8 @@
   }
 }
 
-.coming-up-next {
+.coming-up-next, .crawl-after-dark {
   @include clearfix;
-  margin-bottom: 3em;
 
   .up-next-bg {
     background: url(crawl-up-next-bg.png) no-repeat;
@@ -51,7 +50,7 @@
     height: 200px;
     padding-top: 7em;
   }
-  .next-events {
+  .next-events, .after-dark-events {
     @include container;
     padding: 2em 0;
 
@@ -61,7 +60,7 @@
 
     .up-next-event {
       position: relative;
-      margin-bottom: 2em;
+      margin-bottom: 5em;
       @include column(12);
       @include breakpoint($breakpoint-l) {
         @include column(6);
@@ -118,7 +117,6 @@
 
 .crawl-after-dark {
   background-color: $link-color;
-  padding-bottom: 3em;
   .after-dark-bg {
     background: url(crawl-after-dark-bg.png) no-repeat $link-color;
     background-size: cover;
@@ -130,6 +128,17 @@
   }
   .after-dark-events {
     padding: 2em 0;
+    .up-next-events {
+      .title a {
+        color: #fff;
+
+      }
+    }
+    .up-next-event {
+      img {
+        width: 100%;
+      }
+    }
   }
 }
 

--- a/app/views/festivity_events/show.html.haml
+++ b/app/views/festivity_events/show.html.haml
@@ -60,23 +60,23 @@
     .callout.dates
       %h3.callout-title
         Dates/Times
-      - if @event.performances.count < 4
-        %ul
-          - @event.performances.each do |perf|
-            %li
-              %span.day
-                = perf.start_date.strftime("%A, %B %d")
-              %span.time
-                = perf.start_date.strftime("%I:%M%p").downcase
-                = "-"
-                = perf.end_date.strftime("%I:%M%p").downcase
-      - else
+      %ul
+        - performances = @event.performances.take(4)
+        - performances.each do |perf|
+          %li
+            %span.day
+              = perf.start_date.strftime("%A, %B %d")
+            %span.time
+              = perf.start_date.strftime("%I:%M%p").downcase
+              = "-"
+              = perf.end_date.strftime("%I:%M%p").downcase
+      - if @event.performances.count > 4
         %span.toggler-root
           %button.toggler-trigger{aria: {expanded: "false", controls: 'multiple-dates'}}
-            Show All
+            Show More
           .toggler-content.multiple-dates{aria: {hidden: "true"}}
             %ul
-              - @event.performances.each do |perf|
+              - @event.performances.drop(4).each do |perf|
                 %li
                   %span.day
                     = perf.start_date.strftime("%A, %B %d")

--- a/app/views/festivity_events/show.html.haml
+++ b/app/views/festivity_events/show.html.haml
@@ -89,6 +89,12 @@
         %h3.callout-title
           Connect with this artist
         %ul
+          - if @event.has_instagram?
+            %li
+              = link_to @event.artist_instagram, target: "_blank" do
+                %span.icon-instagram{:data => {'grunticon-embed' => true}}
+                %span.icon-text
+                  Instagram
           - if @event.has_twitter?
             %li
               = link_to @event.artist_twitter, target: "_blank" do


### PR DESCRIPTION
I knocked out a bunch of small tickets for festivity for the next gem upgrade.
Cases: 3019, 3299, 3390, 3337

I added bulleted/ordered list styles in the general sass file
I added the insta link in the event detail page for the artist
I added a show more option for more than 4 dates/times in the event detail page
I also updated the crawl homepage after dark block to be styled properly.
