### PR TITLE
See bugzid: 3652 - Shorten Instagram Posts Text to 160 Characters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-festivity-extension (2.5.11)
+    trusty-festivity-extension (2.5.12)
       actionpack-action_caching (~> 1.1.1)
       chronic (~> 0.10.2)
       dalli-elasticache (~> 0.1.2)
@@ -21,7 +21,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.2)
+    CFPropertyList (2.3.3)
     RedCloth (4.3.2)
     actionmailer (4.2.7.1)
       actionpack (= 4.2.7.1)
@@ -62,7 +62,7 @@ GEM
       tzinfo (~> 1.1)
     acts_as_list (0.4.0)
       activerecord (>= 3.0)
-    acts_as_tree (2.5.0)
+    acts_as_tree (2.5.1)
       activerecord (>= 3.0.0)
     addressable (2.4.0)
     arel (6.0.3)
@@ -528,4 +528,4 @@ DEPENDENCIES
   trustygems (~> 0.1.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/views/social/_instagram_posts.html.haml
+++ b/app/views/social/_instagram_posts.html.haml
@@ -8,7 +8,7 @@
             = image_tag post.standard_res_image_url, class: "insta-image", alt: "Lead Image"
           .post-text
             %p.post
-              = post.text
+              = post.text.truncate(160)
             %span.user-account
               = "@#{post.user_username}"
             %time

--- a/lib/trusty-festivity-extension.rb
+++ b/lib/trusty-festivity-extension.rb
@@ -1,5 +1,5 @@
 module TrustyFestivityExtension
-  VERSION     = "2.5.11"
+  VERSION     = "2.5.12"
   SUMMARY     = "Festival microsite engine for Trusty CMS"
   DESCRIPTION = "Event management for arts festivals."
   URL         = "http://github.com/pgharts/trusty-festivity-extension"


### PR DESCRIPTION
Delivers: https://pct.fogbugz.com/f/cases/3652/Shorten-Instagram-Posts-Text-to-160-Characters
