### PR TITLE
BugzID: 3690 -- BuzzwordPGH Homepage styles

### DIFF
--- a/app/assets/stylesheets/skins/buzzword/contexts/_homepage.scss
+++ b/app/assets/stylesheets/skins/buzzword/contexts/_homepage.scss
@@ -2,6 +2,19 @@
   .container {
     width: 100%;
     max-width: 100%;
+    .logo-container, .content-container {
+      @include breakpoint($breakpoint-xl) {
+        @include column(6);
+        @include last;
+        float: right;
+      }
+    }
+    .buzz-mark {
+        width: 75%;
+      @include breakpoint($breakpoint-xl) {
+        width: 100%;
+      }
+    }
     .buzz-intro-background {
       @include breakpoint($breakpoint-nav) {
         height: 550px;
@@ -24,10 +37,14 @@
 
   .main {
     @include container;
-    margin-top: -1em;
-    width: 95%;
-    @include breakpoint($breakpoint-nav) {
-      padding-top: 0;
+    height: 250px;
+    @include breakpoint($breakpoint-l) {
+      height: 325px;
+    }
+    @include breakpoint($breakpoint-xl) {
+      height: 200px;
+      margin-top: 5em;
+      width: 95%;
     }
     .headline {
       @include heading-6;
@@ -61,6 +78,7 @@
     }
   }
   .announcements {
+    clear: both;
     background: none;
     background-color: #0b7b40;
     padding-top: 2em;
@@ -126,4 +144,8 @@
     }
   }
 
+}
+
+.home .social-footer {
+  margin-top: -3.1em;
 }

--- a/db/content/layouts/buzzword/base.html
+++ b/db/content/layouts/buzzword/base.html
@@ -12,11 +12,13 @@
     <r:festivity_meta />
     <meta content='width=device-width, initial-scale=1' name='viewport'>
     <link rel="stylesheet" media="all" href="/assets/skins/buzzword/skin.css">
+
+    <!--<link rel="stylesheet" media="all" href="http://testbuzzwordpgh.trustarts.org:9090/production/assets/skins/buzzword/skin.css">-->
     <script src="/assets/festivity_app.js"></script>
     <script>
         (function(d) {
             var config = {
-                        kitId: 'uqf2ehu',
+                        kitId: 'zbe5prw',
                         scriptTimeout: 3000,
                         async: true
                     },
@@ -33,75 +35,11 @@
         <link href="/assets/grunticon/production/icons.fallback.css" rel="stylesheet"></link>
     </noscript>
 </head>
-<body class="traf <r:festivity_body_class />">
+<body class="buzzword <r:festivity_body_class />">
 <div class="overflow-wrapper">
     <div class="menu-content-wrapper">
         <r:festivity_mobile_menus />
-        <header class="site-header">
-            <div class="container">
-                <section class="traf-mark">
-                    <a class="traf-logo" href="/">
-                        <h1 class="site-name visually-hidden">Three Rivers Arts Festival</h1>
-                        <r:snippet name="traf_logo" />
-                    </a>
-                </section>
-                <div class="mobile-navigation">
-                    <button class="menu-trigger">
-                        <div class="iconmenu-button x">
-                            <span class="iconmenu"></span>
-                        </div>
-                        <span class="trigger-text">Menu</span>
-                </div>
-                <div class="nav-wrapper">
-                    <form action="/search" class="site-search">
-                        <label for="site-search"><span class="visually-hidden">Search</span></label>
-                        <input id="site-search" name="q" placeholder="Search..." type="text"></input>
-                        <button class="search-submit" type="submit">
-                            <span class="icon-search" data-grunticon-embed="true"></span>
-    <span class="visually-hidden">
-      Search
-    </span>
-                        </button>
-                    </form>
-                    <nav class="utility-navigation" role="navigation">
-                        <ul>
-                            <li>
-                                <a href="/traf_home/about/faq">FAQ</a>
-                            </li>
-                            <li>
-                                <a href="/traf_home/visit/map">Map</a>
-                            </li>
-                            <li>
-                                <a href="/traf_home/contact">Contact Us</a>
-                            </li>
-                            <li>
-                                <a href="/events">Schedule</a>
-                            </li>
-                        </ul>
-
-                    </nav>
-
-                    <nav class="primary-navigation" role="navigation">
-                        <ul>
-                            <li>
-                                <a href="/events">Events</a>
-                            </li>
-                            <li>
-                                <a href="/traf_home/visit">Plan Your Visit</a>
-                            </li>
-                            <li>
-                                <a href="/traf_home/get-involved">Get Involved</a>
-                            </li>
-
-                            <li>
-                                <a href="/traf_home/about">About</a>
-                            </li>
-                        </ul>
-                    </nav>
-
-                </div>
-            </div>
-        </header>
+        <header class="site-header"></header>
 
         <main class="main-content" role="main">
             <div class="container">
@@ -112,35 +50,35 @@
             <div class="container">
                 <h3 class="title">Connect with us:</h3>
                 <ul class="social-link-item-group">
-                    <li class="social-link-item">
+                    <!--<li class="social-link-item">
                         <a href="https://www.instagram.com/3RiversArtsFest/">
                             <span class="icon-instagram" data-grunticon-embed="true"></span>
       <span class="visually-hidden">
         Follow the Three Rivers Arts Festival on Instagram
       </span>
                         </a>
-                    </li>
+                    </li>-->
                     <li class="social-link-item">
-                        <a href="https://www.facebook.com/3RiversArtsFest/">
+                        <a href="https://www.facebook.com/buzzwordpgh/events">
                             <span class="icon-facebook" data-grunticon-embed="true"></span>
-      <span class="visually-hidden">
-        Follow the Three Rivers Arts Festival on Facebook
+                            <span class="visually-hidden">
+        Follow Buzzword on Facebook
       </span>
                         </a>
                     </li>
                     <li class="social-link-item">
-                        <a href="https://twitter.com/3RiversArtsFest">
+                        <a href="https://twitter.com/buzzwordpgh">
                             <span class="icon-twitter" data-grunticon-embed="true"></span>
-      <span class="visually-hidden">
-        Follow the Three Rivers Arts Festival on Twitter
+                            <span class="visually-hidden">
+        Follow Buzzword on Twitter
       </span>
                         </a>
                     </li>
                     <li class="social-link-item">
-                        <a href="http://clicks.skem1.com/signup/?c=vNHhx&lid=43">
+                        <a href="mailto:buzzword@trustarts.org">
                             <span class="icon-envelope" data-grunticon-embed="true"></span>
-      <span class="visually-hidden">
-        Sign up for the Three Rivers Arts Fesitval Email Newsletter
+                            <span class="visually-hidden">
+        Email Us
       </span>
                         </a>
                     </li>
@@ -152,59 +90,65 @@
             <div class="container">
                 <nav class="footer-navigation" role="navigation">
                     <ul class="general">
+                        <!--<a class="cultural-trust-logo" href="http://www.trustarts.org">
+                            <h4 class="visually-hidden">Pittsburgh Cultural Trust</h4>
+                            <r:snippet name="buzzword_footer_logo" />
+                        </a>-->
                         <a class="cultural-trust-logo" href="http://www.trustarts.org">
                             <h4 class="visually-hidden">Pittsburgh Cultural Trust</h4>
-                            <r:snippet name="traf_footer_logo" />
+                            <img src="http://festivity-dev.s3.amazonaws.com/sipple/pnc.png" alt="PNC">
                         </a>
-                        <li>
-                            <a href="http://www.trustarts.org/about">About the Trust</a>
-                        </li>
-                        <li>
-                            <a href="http://pressroom.trustarts.org/">Press Room</a>
-                        </li>
-                        <li>
-                            <a href="http://www.trustarts.org/about/privacy-policy">Privacy Policy</a>
-                        </li>
-                        <li>
-                            <a href="http://www.trustarts.org/connect/contact_us/">Contact Us</a>
-                        </li>
 
-                    </ul>
-                    <ul class="attending">
-                        <h4>Attending</h4>
-                        <li>
-                            <a href="/traf_home/visit/parking-transportation/">Parking and Transportation</a>
-                        </li>
-                        <li>
-                            <a href="/traf_home/visit/food-drinks/">Food</a>
-                        </li>
-                        <li>
-                            <a href="/traf_home/visit/accessibility/">Accessibility</a>
-                        </li>
                     </ul>
                     <ul class="artists">
-                        <h4>Get Involved					</h4>
+                        <h4>Partners					</h4>
                         <li>
-                            <a href="/traf_home/get-involved/sing-off/">Sing Off</a>
+                            <a href="http://www.carnegiesciencecenter.org/">Carnegie Science Center</a>
                         </li>
                         <li>
-                            <a href="/traf_home/get-involved/parade-workshops/">Parade Workshops</a>
+                            <a href="https://pittsburghkids.org/">Children's Museum of Pittsburgh</a>
                         </li>
                         <li>
-                            <a href="/traf_home/get-involved/volunteer/">Volunteer</a>
+                            <a href="http://otsummerfest.org/">Opera Theater of Pittsburgh</a>
                         </li>
                         <li>
-                            <a href="/traf_home/about/current-supporters">Current Supporters</a>
+                            <a href="http://www.pbt.org/">Pittsburgh Ballet Theatre</a>
+                        </li>
+                        <li>
+                            <a href="http://www.trustarts.org/">Pittsburgh Cultural Trust</a>
+                        </li>
+                        <li>
+                            <a href="http://www.pittsburghparks.org/">Pittsburgh Parks Conservancy</a>
                         </li>
 
                     </ul>
+
                     <ul class="Blog">
-                        <h4>Blog					</h4>
+                        <h4>Resources					</h4>
                         <li>
-                            <a href="/traf_home/blog/new-facebook-twitter-and-instagram">NEW Facebook, Twitter and Instagram</a>
+                            <a href="http://www.carnegielibrary.org/">Carnegie Library</a>
                         </li>
                         <li>
-                            <a href="/traf_home/blog/admission-buttons-now-on-sale">Admission buttons now on sale</a>
+                            <a href="http://www.paeyc.org/">PAEYC</a>
+                        </li>
+                        <li>
+                            <a href="https://www.pnc.com/en/about-pnc/corporate-responsibility/grow-up-great/lesson-center.html">PNC Grow Up Great</a>
+                        </li>
+                    </ul>
+
+                    <ul class="involvement">
+                        <h4>Say Hi!</h4>
+                        <li>
+                            <a href="tel:412.456.7024">412.456.7024</a>
+                        </li>
+                        <li>
+                            <a href="mailto:buzzword@trustarts.org">buzzword@trustarts.org</a>
+                        </li>
+                        <li>
+                            <a href="#">803 Liberty Ave</a>
+                        </li>
+                        <li>
+                            <a href="#">Pittsburgh, PA 15222</a>
                         </li>
                     </ul>
                 </nav>
@@ -215,7 +159,7 @@
         </footer>
     </div>
 </div>
-<script src="https://s3.amazonaws.com/festivity-prod/omniture/firstnight/AppMeasurement.js" type="text/javascript"></script>
+<!--<script src="/omniture/traf/AppMeasurement.js" type="text/javascript"></script>-->
 <r:omniture_vars />
 </body>
 </html>

--- a/db/content/layouts/buzzword/cms_home.html
+++ b/db/content/layouts/buzzword/cms_home.html
@@ -1,0 +1,51 @@
+<div class="main">
+    <div class="logo-container">
+        <section class="buzz-mark">
+            <a class="buzz-logo" href="/">
+                <h1 class="site-name visually-hidden">Buzzword PGH</h1>
+                <r:snippet name="buzzword_logo" />
+            </a>
+        </section>
+    </div>
+    <div class="content-container">
+        <p class="headline-2"><span style="font-size: 1.5em;">Buzzword Pittsburgh</span> was created to excite children and families as they discover the words that are all around them. Through talk and play about math, science, and art, families will expand their young children&rsquo;s vocabulary and conversation skills. The program will engage families and community organizations in Pittsburgh&rsquo;s Homewood neighborhood and the greater community.
+            <br/><br/>
+            The Buzzword Pittsburgh collaborative consists of six partner organizations with expertise in the arts and sciences. They will provide interactive learning opportunities that will encourage imagination, investigation, creation, and reflection. This initiative is supported by PNC Grow Up Great.</p>
+
+        <div class="buttons">
+            <div class="button-wrapper"><a class="button-highlight" href="https://www.facebook.com/buzzwordpgh/events" target="_blank">Upcoming Events</a></div>
+
+            <div class="button-wrapper"><a class="button-highlight" href="http://buzzwordpgh.org/wp-content/uploads/2014/11/Buzz-Words_Web.pdf" target="_blank">Buzzwords List</a></div>
+        </div>
+    </div>
+</div>
+
+<div class="buzz-intro-background"></div>
+
+    <div class="announcements"><!-- comment out the below if needed -->
+        <div class="announcements-container">
+            <div class="announcements-header">
+                <h4>The Three Bs</h4>
+            </div>
+
+            <div class="announcements-group">
+                <div class="announcement-item-group">
+                    <div class="date">Be Present!</div>
+
+                    <div class="announcement-item">Use pictures, words, and definitions to investigate art, math, and science! Engage your child&rsquo;s curiosity by saying new words, repeating them, and explaining their meanings.</div>
+                </div>
+
+                <div class="announcement-item-group">
+                    <div class="date">Be Playful!</div>
+
+                    <div class="announcement-item">Have fun with vocabulary! To make words come to life you can talk, write, read, play, and sing with your child.</div>
+                </div>
+
+                <div class="announcement-item-group">
+                    <div class="date">Be Proactive!</div>
+
+                    <div class="announcement-item">You child is curious! Explore fun and easy activities that take one word and build upon it. Your child&#39;s world will open up &ndash; there will always be new words, fresh meanings, and exciting ways to apply them to everyday life!</div>
+                </div>
+            </div>
+        </div>
+    </div>


### PR DESCRIPTION
Updated the homepage styles to put the logo and paragraphs on one line, 2 columns
Updates the responsiveness of the page so no overlap occurs over the pgh skyline.
Moves the footer up -3.1em so there is no space between the announcements div and the footer.
